### PR TITLE
🎲 PRG'yi başka PRG ile seed etmek yerine gerçek 64 rastgele byte ile seed et.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-# Makefile artifacts
+.vscode
 *.o
 *.so
-cache-opencl.*
 bin
+cache-opencl.*
 profanity

--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -90,26 +90,14 @@ cl_kernel Dispatcher::Device::createKernel(cl_program & clProgram, const std::st
 }
 
 cl_ulong4 Dispatcher::Device::createSeed() {
-#ifdef PROFANITY_DEBUG
+	std::random_device rd("/dev/random");
 	cl_ulong4 r;
-	r.s[0] = 1;
-	r.s[1] = 1;
-	r.s[2] = 1;
-	r.s[3] = 1;
+	r.s[0] = (((uint64_t) rd()) << 32) | rd();
+	r.s[1] = (((uint64_t) rd()) << 32) | rd();
+	r.s[2] = (((uint64_t) rd()) << 32) | rd();
+	r.s[3] = (((uint64_t) rd()) << 32) | rd();
+	printf("Şu rastgele sayılar kullanılıyor: %llx, %llx, %llx, %llx\n", r.s[0], r.s[1], r.s[2], r.s[3]);
 	return r;
-#else
-	// Randomize private keys
-	std::random_device rd;
-	std::mt19937_64 eng(rd());
-	std::uniform_int_distribution<cl_ulong> distr;
-
-	cl_ulong4 r;
-	r.s[0] = distr(eng);
-	r.s[1] = distr(eng);
-	r.s[2] = distr(eng);
-	r.s[3] = distr(eng);
-	return r;
-#endif
 }
 
 Dispatcher::Device::Device(Dispatcher & parent, cl_context & clContext, cl_program & clProgram, cl_device_id clDeviceId, const size_t worksizeLocal, const size_t size, const size_t index, const Mode & mode) :

--- a/eulogy.py
+++ b/eulogy.py
@@ -12,14 +12,18 @@ def contract_address(sender: str, nonce=0) -> str:
     address_bytes = h[12:]
     return to_checksum_address(address_bytes)
 
+Count = 0
+
 def f(priv):
+    global Count
     acc = Account.from_key(priv)
     deployer = acc.address
     deployed = contract_address(acc.address)
+    Count += 1
     if deployed.startswith("0xcCc") and deployed.endswith("cCc"):
-        print("Found: ", priv, deployer, deployed)
+        print(f"C: {Count}  Hit: {deployed} {priv} {deployer}")
     else:
-        print("Missed:", priv, deployer, deployed)
+        print(f"C: {Count} Miss: {deployed} {priv} {deployer}")
 
 
 started = False


### PR DESCRIPTION
https://blog.1inch.io/a-vulnerability-disclosed-in-profanity-an-ethereum-vanity-address-tool-68ed7455fc8c

KimlikDAO sadece kontratlarda vanity adres kullanıyor ve bizim deployer'larımızın **HİÇ BİR** özel hakkı yok. Buna rağmen deployer private keyleri snowtrace.io, etherscan.io gibi mecralarda kontratlari claim etmek için kullanılabiliyor. Dolayısıyla vanity adres aracımız `eulogy`'yi güncelleyip vanity adreslerimizi tekrar yaratıyoruz.